### PR TITLE
Added two missing 2450 namespaces

### DIFF
--- a/server/src/instrument/2450/index.ts
+++ b/server/src/instrument/2450/index.ts
@@ -338,6 +338,13 @@ const script: ApiSpec = {
     label: 'script'
 }
 
+const smuInterlock: ApiSpec = {
+    children: [
+        { label: 'smu.interlock.tripped' },
+    ],
+    label: 'smu.interlock'
+}
+
 const smuMeasureAutozero: ApiSpec = {
     children: [
         { label: 'smu.measure.autozero.enable' },
@@ -677,6 +684,19 @@ const triggerLanout: ApiSpec = {
     label: 'trigger.lanout'
 }
 
+const triggerModel: ApiSpec = {
+    children: [
+        { label: 'trigger.model.abort' },
+        { label: 'trigger.model.getblocklist' },
+        { label: 'trigger.model.getbranchcount' },
+        { label: 'trigger.model.initiate' },
+        { label: 'trigger.model.load' },
+        { label: 'trigger.model.setblock' },
+        { label: 'trigger.model.state' },
+    ],
+    label: 'trigger.model'
+}
+
 const triggerTimerStart: ApiSpec = {
     children: [
         { label: 'trigger.timer.start.fractionalseconds' },
@@ -946,6 +966,7 @@ export function get2450ApiSpec(): Array<ApiSpec> {
         printnumber,
         reset,
         script,
+        smuInterlock,
         smuMeasureAutozero,
         smuMeasureConfiglist,
         smuMeasureFilter,
@@ -972,6 +993,7 @@ export function get2450ApiSpec(): Array<ApiSpec> {
         triggerDigout,
         triggerLanin,
         triggerLanout,
+        triggerModel,
         triggerTimerStart,
         triggerTimer,
         triggerTsplinkin,

--- a/server/src/instrument/2450/index.ts
+++ b/server/src/instrument/2450/index.ts
@@ -25,6 +25,14 @@ const beeper: ApiSpec = {
     label: 'beeper'
 }
 
+const bufferWrite: ApiSpec = {
+    children: [
+        { label: 'buffer.write.format' },
+        { label: 'buffer.write.reading' },
+    ],
+    label: 'buffer.write'
+}
+
 const buffer: ApiSpec = {
     children: [
         { label: 'buffer.clearstats' },
@@ -90,14 +98,6 @@ const buffer: ApiSpec = {
     label: 'buffer'
 }
 
-const bufferWrite: ApiSpec = {
-    children: [
-        { label: 'buffer.write.format' },
-        { label: 'buffer.write.reading' },
-    ],
-    label: 'buffer.write'
-}
-
 const createconfigscript: ApiSpec = { label: 'createconfigscript' }
 
 const dataqueue: ApiSpec = {
@@ -112,6 +112,15 @@ const dataqueue: ApiSpec = {
 }
 
 const delay: ApiSpec = { label: 'delay' }
+
+const digioLine: ApiSpec = {
+    children: [
+        { label: 'digio.line.mode' },
+        { label: 'digio.line.reset' },
+        { label: 'digio.line.state' },
+    ],
+    label: 'digio.line'
+}
 
 const digio: ApiSpec = {
     children: [
@@ -133,13 +142,14 @@ const digio: ApiSpec = {
     label: 'digio'
 }
 
-const digioLine: ApiSpec = {
+const displayInput: ApiSpec = {
     children: [
-        { label: 'digio.line.mode' },
-        { label: 'digio.line.reset' },
-        { label: 'digio.line.state' },
+        { label: 'display.input.number' },
+        { label: 'display.input.option' },
+        { label: 'display.input.prompt' },
+        { label: 'display.input.string' },
     ],
-    label: 'digio.line'
+    label: 'display.input'
 }
 
 const display: ApiSpec = {
@@ -205,16 +215,6 @@ const display: ApiSpec = {
         { label: 'display.TEXT2' },
     ],
     label: 'display'
-}
-
-const displayInput: ApiSpec = {
-    children: [
-        { label: 'display.input.number' },
-        { label: 'display.input.option' },
-        { label: 'display.input.prompt' },
-        { label: 'display.input.string' },
-    ],
-    label: 'display.input'
 }
 
 const eventlog: ApiSpec = {
@@ -338,87 +338,6 @@ const script: ApiSpec = {
     label: 'script'
 }
 
-const smu: ApiSpec = {
-    children: [
-        { label: 'smu.reset' },
-    ],
-    enums: [
-        { label: 'smu.AUDIBLE_FAIL' },
-        { label: 'smu.AUDIBLE_NONE' },
-        { label: 'smu.AUDIBLE_PASS' },
-        { label: 'smu.DELAY_AUTO' },
-        { label: 'smu.DIGITS_3_5' },
-        { label: 'smu.DIGITS_4_5' },
-        { label: 'smu.DIGITS_5_5' },
-        { label: 'smu.DIGITS_6_5' },
-        { label: 'smu.FAIL_BOTH' },
-        { label: 'smu.FAIL_HIGH' },
-        { label: 'smu.FAIL_LOW' },
-        { label: 'smu.FAIL_NONE' },
-        { label: 'smu.FILTER_MOVING_AVG' },
-        { label: 'smu.FILTER_REPEAT_AVG' },
-        { label: 'smu.FUNC_DC_CURRENT' },
-        { label: 'smu.FUNC_DC_VOLTAGE' },
-        { label: 'smu.FUNC_RESISTANCE' },
-        { label: 'smu.INFINITE' },
-        { label: 'smu.MATH_MXB' },
-        { label: 'smu.MATH_PERCENT' },
-        { label: 'smu.MATH_RECIPROCAL' },
-        { label: 'smu.OFF' },
-        { label: 'smu.OFFMODE_GUARD' },
-        { label: 'smu.OFFMODE_HIGHZ' },
-        { label: 'smu.OFFMODE_NORMAL' },
-        { label: 'smu.OFFMODE_ZERO' },
-        { label: 'smu.ON' },
-        { label: 'smu.PROTECT_2V' },
-        { label: 'smu.PROTECT_5V' },
-        { label: 'smu.PROTECT_10V' },
-        { label: 'smu.PROTECT_20V' },
-        { label: 'smu.PROTECT_40V' },
-        { label: 'smu.PROTECT_60V' },
-        { label: 'smu.PROTECT_80V' },
-        { label: 'smu.PROTECT_100V' },
-        { label: 'smu.PROTECT_120V' },
-        { label: 'smu.PROTECT_140V' },
-        { label: 'smu.PROTECT_160V' },
-        { label: 'smu.PROTECT_180V' },
-        { label: 'smu.PROTECT_NONE' },
-        { label: 'smu.RANGE_AUTO' },
-        { label: 'smu.RANGE_BEST' },
-        { label: 'smu.RANGE_FIXED' },
-        { label: 'smu.SENSE_2WIRE' },
-        { label: 'smu.SENSE_4WIRE' },
-        { label: 'smu.TERMINALS_FRONT' },
-        { label: 'smu.TERMINALS_REAR' },
-        { label: 'smu.UNIT_AMP' },
-        { label: 'smu.UNIT_OHM' },
-        { label: 'smu.UNIT_VOLT' },
-        { label: 'smu.UNIT_WATT' },
-    ],
-    label: 'smu'
-}
-
-const smuMeasure: ApiSpec = {
-    children: [
-        { label: 'smu.measure.autorange' },
-        { label: 'smu.measure.autorangehigh' },
-        { label: 'smu.measure.autorangelow' },
-        { label: 'smu.measure.count' },
-        { label: 'smu.measure.displaydigits' },
-        { label: 'smu.measure.func' },
-        { label: 'smu.measure.nplc' },
-        { label: 'smu.measure.offsetcompensation' },
-        { label: 'smu.measure.range' },
-        { label: 'smu.measure.read' },
-        { label: 'smu.measure.readwithtime' },
-        { label: 'smu.measure.sense' },
-        { label: 'smu.measure.terminals' },
-        { label: 'smu.measure.unit' },
-        { label: 'smu.measure.userdelay' },
-    ],
-    label: 'smu.measure'
-}
-
 const smuMeasureAutozero: ApiSpec = {
     children: [
         { label: 'smu.measure.autozero.enable' },
@@ -500,25 +419,25 @@ const smuMeasureRel: ApiSpec = {
     label: 'smu.measure.rel'
 }
 
-const smuSource: ApiSpec = {
+const smuMeasure: ApiSpec = {
     children: [
-        { label: 'smu.source.autodelay' },
-        { label: 'smu.source.autorange' },
-        { label: 'smu.source.delay' },
-        { label: 'smu.source.func' },
-        { label: 'smu.source.highc' },
-        { label: 'smu.source.level' },
-        { label: 'smu.source.offmode' },
-        { label: 'smu.source.output' },
-        { label: 'smu.source.range' },
-        { label: 'smu.source.readback' },
-        { label: 'smu.source.sweeplinear' },
-        { label: 'smu.source.sweeplinearstep' },
-        { label: 'smu.source.sweeplist' },
-        { label: 'smu.source.sweeplog' },
-        { label: 'smu.source.userdelay' },
+        { label: 'smu.measure.autorange' },
+        { label: 'smu.measure.autorangehigh' },
+        { label: 'smu.measure.autorangelow' },
+        { label: 'smu.measure.count' },
+        { label: 'smu.measure.displaydigits' },
+        { label: 'smu.measure.func' },
+        { label: 'smu.measure.nplc' },
+        { label: 'smu.measure.offsetcompensation' },
+        { label: 'smu.measure.range' },
+        { label: 'smu.measure.read' },
+        { label: 'smu.measure.readwithtime' },
+        { label: 'smu.measure.sense' },
+        { label: 'smu.measure.terminals' },
+        { label: 'smu.measure.unit' },
+        { label: 'smu.measure.userdelay' },
     ],
-    label: 'smu.source'
+    label: 'smu.measure'
 }
 
 const smuSourceConfiglist: ApiSpec = {
@@ -556,6 +475,87 @@ const smuSourceVlimit: ApiSpec = {
         { label: 'smu.source.vlimit.tripped' },
     ],
     label: 'smu.source.vlimit'
+}
+
+const smuSource: ApiSpec = {
+    children: [
+        { label: 'smu.source.autodelay' },
+        { label: 'smu.source.autorange' },
+        { label: 'smu.source.delay' },
+        { label: 'smu.source.func' },
+        { label: 'smu.source.highc' },
+        { label: 'smu.source.level' },
+        { label: 'smu.source.offmode' },
+        { label: 'smu.source.output' },
+        { label: 'smu.source.range' },
+        { label: 'smu.source.readback' },
+        { label: 'smu.source.sweeplinear' },
+        { label: 'smu.source.sweeplinearstep' },
+        { label: 'smu.source.sweeplist' },
+        { label: 'smu.source.sweeplog' },
+        { label: 'smu.source.userdelay' },
+    ],
+    label: 'smu.source'
+}
+
+const smu: ApiSpec = {
+    children: [
+        { label: 'smu.reset' },
+    ],
+    enums: [
+        { label: 'smu.AUDIBLE_FAIL' },
+        { label: 'smu.AUDIBLE_NONE' },
+        { label: 'smu.AUDIBLE_PASS' },
+        { label: 'smu.DELAY_AUTO' },
+        { label: 'smu.DIGITS_3_5' },
+        { label: 'smu.DIGITS_4_5' },
+        { label: 'smu.DIGITS_5_5' },
+        { label: 'smu.DIGITS_6_5' },
+        { label: 'smu.FAIL_BOTH' },
+        { label: 'smu.FAIL_HIGH' },
+        { label: 'smu.FAIL_LOW' },
+        { label: 'smu.FAIL_NONE' },
+        { label: 'smu.FILTER_MOVING_AVG' },
+        { label: 'smu.FILTER_REPEAT_AVG' },
+        { label: 'smu.FUNC_DC_CURRENT' },
+        { label: 'smu.FUNC_DC_VOLTAGE' },
+        { label: 'smu.FUNC_RESISTANCE' },
+        { label: 'smu.INFINITE' },
+        { label: 'smu.MATH_MXB' },
+        { label: 'smu.MATH_PERCENT' },
+        { label: 'smu.MATH_RECIPROCAL' },
+        { label: 'smu.OFF' },
+        { label: 'smu.OFFMODE_GUARD' },
+        { label: 'smu.OFFMODE_HIGHZ' },
+        { label: 'smu.OFFMODE_NORMAL' },
+        { label: 'smu.OFFMODE_ZERO' },
+        { label: 'smu.ON' },
+        { label: 'smu.PROTECT_2V' },
+        { label: 'smu.PROTECT_5V' },
+        { label: 'smu.PROTECT_10V' },
+        { label: 'smu.PROTECT_20V' },
+        { label: 'smu.PROTECT_40V' },
+        { label: 'smu.PROTECT_60V' },
+        { label: 'smu.PROTECT_80V' },
+        { label: 'smu.PROTECT_100V' },
+        { label: 'smu.PROTECT_120V' },
+        { label: 'smu.PROTECT_140V' },
+        { label: 'smu.PROTECT_160V' },
+        { label: 'smu.PROTECT_180V' },
+        { label: 'smu.PROTECT_NONE' },
+        { label: 'smu.RANGE_AUTO' },
+        { label: 'smu.RANGE_BEST' },
+        { label: 'smu.RANGE_FIXED' },
+        { label: 'smu.SENSE_2WIRE' },
+        { label: 'smu.SENSE_4WIRE' },
+        { label: 'smu.TERMINALS_FRONT' },
+        { label: 'smu.TERMINALS_REAR' },
+        { label: 'smu.UNIT_AMP' },
+        { label: 'smu.UNIT_OHM' },
+        { label: 'smu.UNIT_VOLT' },
+        { label: 'smu.UNIT_WATT' },
+    ],
+    label: 'smu'
 }
 
 const statusOperation: ApiSpec = {
@@ -618,6 +618,108 @@ const timer: ApiSpec = {
         { label: 'timer.gettime' },
     ],
     label: 'timer'
+}
+
+const triggerBlender: ApiSpec = {
+    children: [
+        { label: 'trigger.blender.clear' },
+        { label: 'trigger.blender.orenable' },
+        { label: 'trigger.blender.overrun' },
+        { label: 'trigger.blender.reset' },
+        { label: 'trigger.blender.stimulus' },
+        { label: 'trigger.blender.wait' },
+    ],
+    label: 'trigger.blender'
+}
+
+const triggerDigin: ApiSpec = {
+    children: [
+        { label: 'trigger.digin.clear' },
+        { label: 'trigger.digin.edge' },
+        { label: 'trigger.digin.overrun' },
+        { label: 'trigger.digin.wait' },
+    ],
+    label: 'trigger.digin'
+}
+
+const triggerDigout: ApiSpec = {
+    children: [
+        { label: 'trigger.digout.assert' },
+        { label: 'trigger.digout.logic' },
+        { label: 'trigger.digout.pulsewidth' },
+        { label: 'trigger.digout.release' },
+        { label: 'trigger.digout.stimulus' },
+    ],
+    label: 'trigger.digout'
+}
+
+const triggerLanin: ApiSpec = {
+    children: [
+        { label: 'trigger.lanin.clear' },
+        { label: 'trigger.lanin.edge' },
+        { label: 'trigger.lanin.overrun' },
+        { label: 'trigger.lanin.wait' },
+    ],
+    label: 'trigger.lanin'
+}
+
+const triggerLanout: ApiSpec = {
+    children: [
+        { label: 'trigger.lanout.assert' },
+        { label: 'trigger.lanout.connect' },
+        { label: 'trigger.lanout.connected' },
+        { label: 'trigger.lanout.disconnect' },
+        { label: 'trigger.lanout.ipaddress' },
+        { label: 'trigger.lanout.logic' },
+        { label: 'trigger.lanout.protocol' },
+        { label: 'trigger.lanout.stimulus' },
+    ],
+    label: 'trigger.lanout'
+}
+
+const triggerTimerStart: ApiSpec = {
+    children: [
+        { label: 'trigger.timer.start.fractionalseconds' },
+        { label: 'trigger.timer.start.generate' },
+        { label: 'trigger.timer.start.overrun' },
+        { label: 'trigger.timer.start.seconds' },
+        { label: 'trigger.timer.start.stimulus' },
+    ],
+    label: 'trigger.timer.start'
+}
+
+const triggerTimer: ApiSpec = {
+    children: [
+        { label: 'trigger.timer.clear' },
+        { label: 'trigger.timer.count' },
+        { label: 'trigger.timer.delay' },
+        { label: 'trigger.timer.delaylist' },
+        { label: 'trigger.timer.enable' },
+        { label: 'trigger.timer.reset' },
+        { label: 'trigger.timer.wait' },
+    ],
+    label: 'trigger.timer'
+}
+
+const triggerTsplinkin: ApiSpec = {
+    children: [
+        { label: 'trigger.tsplinkin.clear' },
+        { label: 'trigger.tsplinkin.edge' },
+        { label: 'trigger.tsplinkin.overrun' },
+        { label: 'trigger.tsplinkin.wait' },
+    ],
+    label: 'trigger.tsplinkin'
+}
+
+const triggerTsplinkout: ApiSpec = {
+    children: [
+        { label: 'trigger.tsplinkout.assert' },
+        { label: 'trigger.tsplinkout.logic' },
+        { label: 'trigger.tsplinkout.pulsewidth' },
+        { label: 'trigger.tsplinkout.release' },
+        { label: 'trigger.tsplinkout.stimulus' },
+    ],
+    label: 'trigger.tsplinkout'
 }
 
 const trigger: ApiSpec = {
@@ -735,108 +837,6 @@ const trigger: ApiSpec = {
     label: 'trigger'
 }
 
-const triggerBlender: ApiSpec = {
-    children: [
-        { label: 'trigger.blender.clear' },
-        { label: 'trigger.blender.orenable' },
-        { label: 'trigger.blender.overrun' },
-        { label: 'trigger.blender.reset' },
-        { label: 'trigger.blender.stimulus' },
-        { label: 'trigger.blender.wait' },
-    ],
-    label: 'trigger.blender'
-}
-
-const triggerDigin: ApiSpec = {
-    children: [
-        { label: 'trigger.digin.clear' },
-        { label: 'trigger.digin.edge' },
-        { label: 'trigger.digin.overrun' },
-        { label: 'trigger.digin.wait' },
-    ],
-    label: 'trigger.digin'
-}
-
-const triggerDigout: ApiSpec = {
-    children: [
-        { label: 'trigger.digout.assert' },
-        { label: 'trigger.digout.logic' },
-        { label: 'trigger.digout.pulsewidth' },
-        { label: 'trigger.digout.release' },
-        { label: 'trigger.digout.stimulus' },
-    ],
-    label: 'trigger.digout'
-}
-
-const triggerLanin: ApiSpec = {
-    children: [
-        { label: 'trigger.lanin.clear' },
-        { label: 'trigger.lanin.edge' },
-        { label: 'trigger.lanin.overrun' },
-        { label: 'trigger.lanin.wait' },
-    ],
-    label: 'trigger.lanin'
-}
-
-const triggerLanout: ApiSpec = {
-    children: [
-        { label: 'trigger.lanout.assert' },
-        { label: 'trigger.lanout.connect' },
-        { label: 'trigger.lanout.connected' },
-        { label: 'trigger.lanout.disconnect' },
-        { label: 'trigger.lanout.ipaddress' },
-        { label: 'trigger.lanout.logic' },
-        { label: 'trigger.lanout.protocol' },
-        { label: 'trigger.lanout.stimulus' },
-    ],
-    label: 'trigger.lanout'
-}
-
-const triggerTimer: ApiSpec = {
-    children: [
-        { label: 'trigger.timer.clear' },
-        { label: 'trigger.timer.count' },
-        { label: 'trigger.timer.delay' },
-        { label: 'trigger.timer.delaylist' },
-        { label: 'trigger.timer.enable' },
-        { label: 'trigger.timer.reset' },
-        { label: 'trigger.timer.wait' },
-    ],
-    label: 'trigger.timer'
-}
-
-const triggerTimerStart: ApiSpec = {
-    children: [
-        { label: 'trigger.timer.start.fractionalseconds' },
-        { label: 'trigger.timer.start.generate' },
-        { label: 'trigger.timer.start.overrun' },
-        { label: 'trigger.timer.start.seconds' },
-        { label: 'trigger.timer.start.stimulus' },
-    ],
-    label: 'trigger.timer.start'
-}
-
-const triggerTsplinkin: ApiSpec = {
-    children: [
-        { label: 'trigger.tsplinkin.clear' },
-        { label: 'trigger.tsplinkin.edge' },
-        { label: 'trigger.tsplinkin.overrun' },
-        { label: 'trigger.tsplinkin.wait' },
-    ],
-    label: 'trigger.tsplinkin'
-}
-
-const triggerTsplinkout: ApiSpec = {
-    children: [
-        { label: 'trigger.tsplinkout.assert' },
-        { label: 'trigger.tsplinkout.logic' },
-        { label: 'trigger.tsplinkout.pulsewidth' },
-        { label: 'trigger.tsplinkout.release' },
-        { label: 'trigger.tsplinkout.stimulus' },
-    ],
-    label: 'trigger.tsplinkout'
-}
-
 const tsplink: ApiSpec = {
     children: [
         { label: 'tsplink.MODE_DIGITAL_OPEN_DRAIN' },
@@ -924,15 +924,15 @@ const waitcomplete: ApiSpec = { label: 'waitcomplete' }
 export function get2450ApiSpec(): Array<ApiSpec> {
     return getLuaApiSpec().concat([
         beeper,
-        buffer,
         bufferWrite,
+        buffer,
         createconfigscript,
         dataqueue,
         delay,
-        digio,
         digioLine,
-        display,
+        digio,
         displayInput,
+        display,
         eventlog,
         exit,
         file,
@@ -946,41 +946,41 @@ export function get2450ApiSpec(): Array<ApiSpec> {
         printnumber,
         reset,
         script,
-        smu,
-        smuMeasure,
         smuMeasureAutozero,
         smuMeasureConfiglist,
         smuMeasureFilter,
-        smuMeasureLimit,
         smuMeasureLimitHigh,
         smuMeasureLimitLow,
+        smuMeasureLimit,
         smuMeasureMath,
         smuMeasureMathMxb,
         smuMeasureRel,
-        smuSource,
+        smuMeasure,
         smuSourceConfiglist,
         smuSourceIlimit,
         smuSourceProtect,
         smuSourceVlimit,
-        status,
+        smuSource,
+        smu,
         statusOperation,
         statusQuestionable,
         statusStandard,
+        status,
         timer,
-        trigger,
         triggerBlender,
         triggerDigin,
         triggerDigout,
         triggerLanin,
         triggerLanout,
-        triggerTimer,
         triggerTimerStart,
+        triggerTimer,
         triggerTsplinkin,
         triggerTsplinkout,
-        tsplink,
+        trigger,
         tsplinkLine,
-        tspnet,
+        tsplink,
         tspnetTsp,
+        tspnet,
         upgrade,
         userstring,
         waitcomplete

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -269,7 +269,7 @@ connection.onSignatureHelp((params: TextDocumentPositionParams) => {
 
     // add all matching signatures to the results array
     for (const signa of tspItem.commandSet.signatures) {
-        const signaBeforeParams: string = signa.label.slice(0, signa.labal.indexOf('('))
+        const signaBeforeParams: string = signa.label.slice(0, signa.label.indexOf('('))
 
         if (signaBeforeParams.localeCompare(unreversed) === 0) {
             results.push(signa)

--- a/test/server/src/instrument/2450/index.test.ts
+++ b/test/server/src/instrument/2450/index.test.ts
@@ -26,21 +26,24 @@ import { emptySpec } from '../emptySpec'
     @test('Exports ApiSpec array')
     exportsCompletions(): void {
         // tslint:disable-next-line:no-magic-numbers
-        assert(Namespace.get2450ApiSpec().length === 68, '2450 ApiSpec contains unknown namespaces')
+        const totalModules = 70
 
+        assert(Namespace.get2450ApiSpec().length === totalModules, 'Unexpected number of 2450 ApiSpec modules')
+
+        const uniqueNamespaces: Map<string, number> = new Map()
         Namespace.get2450ApiSpec().forEach((value: ApiSpec) => {
             switch (value.label) {
                 case 'beeper':
-                case 'buffer':
                 case 'buffer.write':
+                case 'buffer':
                 case 'coroutine':
                 case 'createconfigscript':
                 case 'dataqueue':
                 case 'delay':
-                case 'digio':
                 case 'digio.line':
-                case 'display':
+                case 'digio':
                 case 'display.input':
+                case 'display':
                 case 'eventlog':
                 case 'exit':
                 case 'file':
@@ -58,51 +61,62 @@ import { emptySpec } from '../emptySpec'
                 case 'printnumber':
                 case 'reset':
                 case 'script':
-                case 'smu':
-                case 'smu.measure':
+                case 'smu.interlock':
                 case 'smu.measure.autozero':
                 case 'smu.measure.configlist':
                 case 'smu.measure.filter':
-                case 'smu.measure.limit':
                 case 'smu.measure.limit.high':
                 case 'smu.measure.limit.low':
-                case 'smu.measure.math':
+                case 'smu.measure.limit':
                 case 'smu.measure.math.mxb':
+                case 'smu.measure.math':
                 case 'smu.measure.rel':
-                case 'smu.source':
+                case 'smu.measure':
                 case 'smu.source.configlist':
                 case 'smu.source.ilimit':
                 case 'smu.source.protect':
                 case 'smu.source.vlimit':
-                case 'status':
+                case 'smu.source':
+                case 'smu':
                 case 'status.operation':
                 case 'status.questionable':
                 case 'status.standard':
+                case 'status':
                 case 'string':
                 case 'table':
                 case 'timer':
-                case 'trigger':
                 case 'trigger.blender':
                 case 'trigger.digin':
                 case 'trigger.digout':
                 case 'trigger.lanin':
                 case 'trigger.lanout':
-                case 'trigger.timer':
+                case 'trigger.model':
                 case 'trigger.timer.start':
+                case 'trigger.timer':
                 case 'trigger.tsplinkin':
                 case 'trigger.tsplinkout':
-                case 'tsplink':
+                case 'trigger':
                 case 'tsplink.line':
-                case 'tspnet':
+                case 'tsplink':
                 case 'tspnet.tsp':
+                case 'tspnet':
                 case 'upgrade':
                 case 'userstring':
                 case 'waitcomplete':
+                    uniqueNamespaces.set(
+                        value.label,
+                        (uniqueNamespaces.has(value.label)) ?
+                            uniqueNamespaces[value.label] + 1 :
+                            1
+                    )
+
                     return
                 default:
                     assert(false, '2450 ApiSpec contains an unknown namespace "' + value.label + '"')
             }
         })
+
+        assert(uniqueNamespaces.size === totalModules, '2450 ApiSpec contains duplicate namespaces')
     }
 
     @test('Exports InstrumentSpec')


### PR DESCRIPTION
### Pull Request Checklist
Please review the [Contribution Guidelines](../CONTRIBUTING.md) before submitting.

- [x] Pulling from a topic/feature/bugfix branch (right side).
- [x] Pulling against the `dev` branch (left side).
- [x] Code passes linting.
- [x] Code passes unit tests.
- [x] Code coverage is the same or better.
- [x] You have previously submitted a Contributor License Agreement or have contacted a maintainer to request one.

### Description
* Added missing `smu.interlock` and `trigger.model` namespaces to the 2450.
* Fixed a bug introduced by not following the proper bugfix procedure. See 4d6801d.



<!-- Modified by Tektronix. Original Content developed by the angular-translate team and Pascal Precht and their Pull Request Template available at https://github.com/angular-translate/angular-translate -->
