### PR TITLE
Escaped string before passing to regular expression constructor

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -4,8 +4,18 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@types/escape-string-regexp": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@types/escape-string-regexp/-/escape-string-regexp-1.0.0.tgz",
+            "integrity": "sha512-KAruqgk9/340M4MYYasdBET+lyYN8KMXUuRKWO72f4SbmIMMFp9nnJiXUkJS0HC2SFe4x0R/fLozXIzqoUfSjA=="
+        },
         "@types/luaparse": {
             "version": "file:types/luaparse"
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "luaparse": {
             "version": "0.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,9 @@
         "url": "https://github.com/tektronixofficial/vscode-tsplang"
     },
     "dependencies": {
+        "@types/escape-string-regexp": "^1.0.0",
         "@types/luaparse": "file:types/luaparse",
+        "escape-string-regexp": "^1.0.5",
         "luaparse": "^0.2.1",
         "vscode-languageserver": "^4.4.2"
     },

--- a/server/src/completionProcessor.ts
+++ b/server/src/completionProcessor.ts
@@ -15,6 +15,8 @@
  */
 'use strict'
 
+// tslint:disable-next-line:no-require-imports
+import escapeStringRegexp = require('escape-string-regexp')
 import { CompletionItem } from 'vscode-languageserver'
 
 export function isPartialMatch(content: string, completion: CompletionItem): boolean {
@@ -47,7 +49,7 @@ export function isPartialMatch(content: string, completion: CompletionItem): boo
             return true
         }
 
-        const labelRegexp = new RegExp('^' + lastName + '.*$')
+        const labelRegexp = new RegExp('^' + escapeStringRegexp(lastName) + '.*$')
 
         const matches = completion.label.match(labelRegexp)
 

--- a/test/server/src/completionProcessor.test.ts
+++ b/test/server/src/completionProcessor.test.ts
@@ -111,4 +111,69 @@ function toString(completion: CompletionItem): string {
             '"' + testString + '" did not partially match "' + toString(testCompletion) + '"'
         )
     }
+
+    // Issue #31 - Unescaped regular expression string input.
+    @test('isPartialMatch Unescaped Regexp')
+    isPartialMatchUnescapedRegexpTest(): void {
+        let testStrings: Array<string> = ['(', '[', 'a(', 'a[']
+        let testCompletion: CompletionItem = {
+            label: 'a'
+        }
+        try {
+            testStrings.forEach((str: string) => {
+                isPartialMatch(str, testCompletion)
+            })
+        } catch (err) {
+            assert(
+                false,
+                'Failed to properly escape regular expression input. Raw Error: ' + err
+            )
+        }
+
+        testStrings = ['a(b', 'a[b']
+        testCompletion = {
+            label: 'b'
+        }
+        try {
+            testStrings.forEach((str: string) => {
+                isPartialMatch(str, testCompletion)
+            })
+        } catch (err) {
+            assert(
+                false,
+                'Failed to properly escape regular expression input. Raw Error: ' + err
+            )
+        }
+
+        testStrings = ['a.b(', 'a.b[']
+        testCompletion = {
+            data: ['a'],
+            label: 'b'
+        }
+        try {
+            testStrings.forEach((str: string) => {
+                isPartialMatch(str, testCompletion)
+            })
+        } catch (err) {
+            assert(
+                false,
+                'Failed to properly escape regular expression input. Raw Error: ' + err
+            )
+        }
+
+        testStrings = ['a.b(p', 'a.b[p']
+        testCompletion = {
+            label: 'partial'
+        }
+        try {
+            testStrings.forEach((str: string) => {
+                isPartialMatch(str, testCompletion)
+            })
+        } catch (err) {
+            assert(
+                false,
+                'Failed to properly escape regular expression input. Raw Error: ' + err
+            )
+        }
+    }
 }


### PR DESCRIPTION
### Pull Request Checklist
Please review the [Contribution Guidelines](../CONTRIBUTING.md) before submitting.

- [x] Pulling from a topic/feature/bugfix branch (right side).
- [x] Pulling against the `dev` branch (left side).
- [x] Code passes linting.
- [x] Code passes unit tests.
- [x] Code coverage is the same or better.
- [x] You have previously submitted a Contributor License Agreement or have contacted a maintainer to request one.

### Description
Resolves Issue #31.
* Added the `escape-string-regexp` npm package.
* Implemented said package.
* Added test cases to prevent future regressions. 



<!-- Modified by Tektronix. Original Content developed by the angular-translate team and Pascal Precht and their Pull Request Template available at https://github.com/angular-translate/angular-translate -->
